### PR TITLE
Fix single-node multi-engine races + resume iteration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,62 @@
-# Build / install
+# Local / personal (never push)
+.notes/
+config.local.toml
+.cursor/
+
+# Runtime artifacts
+runs/
+logs/
+*.log
+*.nohup.out
+outputs/
+checkpoints/
+/experiments/
+*.safetensors
+*.pth
+*.bin
+*.pt
+
+# Downloaded training data (regenerate: python -m es_capacity.cli.fetch_train_data)
+# README.md + SHA256 stay committed so the download stays verifiable.
+data/simplerl_*/train.jsonl
+
+# Model / HF caches
+.hf_cache/
+.cache/
+huggingface/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
 *.egg-info/
+.eggs/
 dist/
 build/
 *.egg
-
-# Python cache
-__pycache__/
-*.pyc
-*.pyo
-
-# Experiments & run outputs
-experiments/
-jobs/
-run*/
-misc/
-
-# HuggingFace dataset cache (cache-* shards are transient; data-* shards are real)
-datasets/**/cache-*.arrow
-datasets/**/*.json.gz
-datasets/**/.cache
-
-# Env
 .venv/
 venv/
-env/
+.env
+.env.*
+
+# Editors / OS
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# Jupyter
+.ipynb_checkpoints/
+*.ipynb
+
+# Coverage / test
+.coverage
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Wandb
+wandb/

--- a/SETUP_NOTES.md
+++ b/SETUP_NOTES.md
@@ -1,0 +1,137 @@
+# Setup & debugging notes (for future reference)
+
+This documents *why* the code in this repo differs from a fresh clone of
+https://github.com/VsonicV/es-at-scale.git, and the debugging trail that led
+to each change. See `/workspace/PROGRESS.md` for current status and the
+recommended launch command — this file is the "why," that one is the "what/now."
+
+## Environments
+
+Two separate Python environments exist on this machine — don't mix them up:
+
+1. **`/venv/main`** — the base Vast.ai image's own environment, running the
+   instance's built-in "vLLM API" supervisor service (unrelated to this
+   training job). Has `vllm==0.26.0` installed. Has `es_at_scale` also
+   installed here (`pip install --no-deps -e .`) from early experimentation —
+   harmless leftover, not used for the final approach.
+2. **`/workspace/es-at-scale/.venv`** — dedicated venv for this repo, built
+   with the repo's actual pinned dependencies from `setup.py`
+   (`vllm==0.11.0`, `transformers==4.57.6`). **Use this one for training.**
+
+### Why two environments
+The repo's `setup.py` pins `vllm==0.11.0`, which conflicts with the base
+image's `vllm==0.26.0`. Initially tried running against the newer 0.26.0
+(already installed, faster to get started) rather than the pinned version.
+This led to three separate real bugs (below), all specific to 0.26.0's
+handling of this repo's unusual usage pattern: N independent, co-located,
+single-GPU `LLM()` instances constructed via Ray in one process (not vLLM's
+typical single-engine-per-process or native multi-node data-parallel setup).
+After the third bug (see "CUDA driver error" below) turned out to still be
+unresolved even after eliminating concurrency and isolating three separate
+cache directories, the decision was made to stop reverse-engineering 0.26.0
+internals and just build a venv with the version the repo actually targets.
+**That fully resolved everything on the first try** — an 8-engine smoke test
+passed cleanly with vllm==0.11.0, no patches needed for that version's bugs.
+
+## Code changes in `es_at_scale/trainer/es_trainer.py`
+
+### 1. Version-agnostic `get_ip`/`get_open_port` import
+```python
+try:
+    from vllm.utils.network_utils import get_ip, get_open_port  # vLLM >= 0.20ish
+except ImportError:
+    from vllm.utils import get_ip, get_open_port  # vLLM 0.11.0 (pinned by this repo)
+```
+vLLM moved these between versions. Harmless either way; keeps the file working
+if the venv ever changes vLLM version again.
+
+### 2. `ESNcclLLM.__init__` — per-engine port/cache isolation
+Added an `engine_idx` parameter that sets, before `super().__init__()`:
+- `VLLM_DP_MASTER_PORT` — unique per engine (`29500 + engine_idx*100`)
+- `VLLM_CACHE_ROOT`, `TRITON_CACHE_DIR`, `CUDA_CACHE_PATH` — each pointed at a
+  per-engine subdirectory
+
+**Root cause this was fixing (vLLM 0.26.0 only, confirmed NOT needed under
+0.11.0, but left in place since it's harmless):**
+- With `n_vllm_engines=8` co-located on one node, every engine independently
+  resolves `data_parallel_rank_local` and `data_parallel_master_port` to `0`
+  (traced through `vllm/config/parallel.py`: since `data_parallel_size==1`,
+  it falls back to reading `VLLM_DP_RANK_LOCAL`/`VLLM_DP_MASTER_PORT` from
+  `os.environ`, which are unset → `vllm.envs` defaults both to `0`). This
+  makes every engine compute the *identical* TCPStore bind port
+  (`0 + 100 + 0 = port 100`) — only the first to bind succeeds, the rest die
+  with `EADDRINUSE` / `DistNetworkError`.
+- After fixing the port collision, hit `RuntimeError: CUDA driver error:
+  invalid argument` during `profile_run`/CUDA-graph-capture on every engine
+  except the first. Chased this through three separate shared-cache-directory
+  theories in sequence — `VLLM_CACHE_ROOT` (vLLM's torch.compile artifact
+  cache), `TRITON_CACHE_DIR` (Triton's own kernel cache, separate from the
+  above), `CUDA_CACHE_PATH`/`~/.nv/ComputeCache` (the NVIDIA driver's own
+  PTX→SASS JIT cache) — isolating all three per-engine. **The error persisted
+  regardless.**
+
+### 3. `launch_engines()` — serialized engine construction
+```python
+# was: engines = [ray.remote(...)(ESNcclLLM).remote(...) for idx, strategy in enumerate(strategies)]
+# now: a for-loop that does ray.get(engine.collective_rpc.remote("_set_seed", args=(0,)))
+#      after each engine's construction, before starting the next
+```
+This was the fix that actually resolved the CUDA driver error under 0.26.0.
+Diagnostic trail: even with all three caches isolated, concurrent engine
+launch still failed (always engine 0 succeeds, all others fail identically).
+Serializing engine startup (so only one engine ever compiles/captures CUDA
+graphs at a time) did NOT immediately fix it either on the first retry — the
+*second* engine still failed, in complete isolation, no concurrency at all.
+A follow-up isolation test proved GPU 1 (the second engine's GPU) works fine
+completely on its own — ruling out a hardware fault on that GPU. This pointed
+to some kind of process-sequence-dependent state corruption specific to
+vLLM 0.26.0's compile/capture pipeline when multiple engines are constructed
+in sequence within one process — root cause never fully pinned down, because
+switching to vllm==0.11.0 (below) made the whole problem disappear.
+
+**Cost/benefit of leaving this in for 0.11.0**: only tested 0.11.0 *with*
+this serialization active (never re-tested without it once 0.11.0 was
+installed) — so it's unknown whether 0.11.0 strictly needs it. It adds
+~4-5 minutes to engine startup (8 engines × ~30-40s each, sequential instead
+of parallel) versus a run that lasts hours to days — negligible cost either
+way, so it wasn't worth the risk of re-testing without it. Fine to leave as-is.
+
+### 4. `gpu_memory_utilization` — kept at `0.7`
+Tested `0.85` (more KV cache headroom) — identical wall-clock time to `0.7`
+on the same workload (384.5s vs 384.7s for 1024 prompts @ max_tokens=4096).
+Confirms the workload is compute-bound, not memory-bound, in this regime.
+Reverted to `0.7` since `0.85` gave no benefit and left less headroom for the
+ES-specific weight-perturbation/broadcast tensors (which allocate outside
+vLLM's own memory budget — see `worker_extension.py`'s `perturb_self_weights`
+etc., each does raw `torch.randn` per parameter tensor).
+
+### 5. `start_iteration` param (feature, not a bug fix)
+Added to `__init__` (default `0`) and used in `fit()`:
+```python
+iteration, epoch = self.start_iteration, 0  # was: iteration, epoch = 0, 0
+```
+Without this, `--checkpoint` correctly restores model *weights* but `fit()`
+always restarts its internal iteration counter (and therefore the ES seed
+schedule, since seeds are `global_seed + iteration`) at 0 — so resuming a
+run without this would silently replay the exact same population-perturbation
+seeds already used, and mislabel iteration numbers in logs/W&B. Verified with
+a smoke test (`start_iteration=2, n_iterations=3` correctly ran only
+iterations 2 and 3, not 0-3).
+
+## Code changes in `es_at_scale/train.py`
+Added `--start-iteration` CLI flag (default `0`), wired through to the
+trainer constructor. Use with `--checkpoint` to continue a shorter run into a
+longer one — see the example in `/workspace/PROGRESS.md`.
+
+## Other environment gotchas hit along the way
+- **pip install failures that looked like network timeouts were actually disk
+  space.** `TMPDIR`/pip's cache default to the container's root overlay, which
+  is only 8GB (vs `/workspace`'s 256GB persistent volume). Downloading
+  `vllm==0.11.0`'s dependencies (torch + full CUDA library stack, several GB)
+  filled the root disk mid-download, which pip reported as connection/timeout
+  errors before finally surfacing "No space left on device." Fixed by setting
+  `TMPDIR=/workspace/tmp` and `PIP_CACHE_DIR=/workspace/.pip_cache` before any
+  pip install into `.venv`. If installing more packages later, keep using
+  those env vars (or just always `export` them at the top of the shell).
+- `HF_HOME=/workspace/.hf_home` is now persisted in `/workspace/.env`, so it
+  auto-loads in new shells/sessions — no need to `export` it manually anymore.

--- a/SETUP_NOTES.md
+++ b/SETUP_NOTES.md
@@ -96,7 +96,7 @@ installed) — so it's unknown whether 0.11.0 strictly needs it. It adds
 of parallel) versus a run that lasts hours to days — negligible cost either
 way, so it wasn't worth the risk of re-testing without it. Fine to leave as-is.
 
-### 4. `gpu_memory_utilization` — kept at `0.7`
+### 4. `gpu_memory_utilization` — default `0.7`, now overridable
 Tested `0.85` (more KV cache headroom) — identical wall-clock time to `0.7`
 on the same workload (384.5s vs 384.7s for 1024 prompts @ max_tokens=4096).
 Confirms the workload is compute-bound, not memory-bound, in this regime.
@@ -104,6 +104,38 @@ Reverted to `0.7` since `0.85` gave no benefit and left less headroom for the
 ES-specific weight-perturbation/broadcast tensors (which allocate outside
 vLLM's own memory budget — see `worker_extension.py`'s `perturb_self_weights`
 etc., each does raw `torch.randn` per parameter tensor).
+
+**Update — this is now `ES_VLLM_GPU_MEM_UTIL`, default unchanged at `0.7`.** The
+paragraph above holds on 48GB cards. It does not hold on small-VRAM GPUs, where
+`0.7` is not survivable at all: the headroom it leaves is smaller than what the
+ES weight update needs.
+
+`update_weights_from_seeds` holds three tensors live at once for each parameter —
+an fp32 accumulator, the bf16 noise, and `noise.to(torch.float32) * coeffs[i]`.
+On Qwen2.5-1.5B's tied `151936x1536` embedding that peaks at **~2.2GB** for that
+one parameter, and it OOMs at `worker_extension.py:121` *after generation has
+already succeeded*, which makes it look like a training bug rather than a
+budgeting one.
+
+Two env knobs, both defaulting to the previous behaviour so nothing changes on
+the boxes this file was written for:
+
+| var | default | when to set it |
+|---|---|---|
+| `ES_VLLM_GPU_MEM_UTIL` | `0.7` | lower it until `total - vLLM budget` exceeds ~2.5GB |
+| `ES_VLLM_MAX_MODEL_LEN` | unset (model's own) | set to `max_prompt + max_tokens` when the KV cache cannot hold the model's full context |
+
+The second is not optional once the first is lowered: Qwen2.5's own
+`max_model_len` is **131072**, and below roughly `0.55` on a 12GB card the KV
+cache can no longer hold it, so vLLM refuses to start rather than degrading.
+
+Verified on 8x RTX 3060 12GB with `0.6` / `4096`: 2.63GiB and 98,352 tokens of
+KV cache per engine, two training iterations, checkpoint written.
+
+**Peak is reducible if this ever becomes binding on a larger model.**
+`update_accumulator.add_(noise, alpha=coeffs[i])` would drop the separate fp32
+`term` and cut ~892MiB off the peak. Left alone deliberately — it changes the
+accumulation numerics, which is a training-math decision, not a memory fix.
 
 ### 5. `start_iteration` param (feature, not a bug fix)
 Added to `__init__` (default `0`) and used in `fit()`:

--- a/es_at_scale/train.py
+++ b/es_at_scale/train.py
@@ -55,6 +55,8 @@ def main():
                         help="Selects reward function, prompt template, and dataset loader.")
     parser.add_argument("--model-name", type=str, default="Qwen/Qwen2.5-1.5B-Instruct")
     parser.add_argument("--checkpoint", type=str)
+    parser.add_argument("--start-iteration", type=int, default=0,
+                        help="Iteration number to resume counting/seeding from (use with --checkpoint to continue a prior run smoothly).")
     parser.add_argument("--sigma", type=float, default=0.001)
     parser.add_argument("--alpha", type=float, default=-1)
     parser.add_argument("--reward-shaping", type=str, default="z-scores")
@@ -164,8 +166,8 @@ def main():
         wandb_project=args.wandb_project,
         save_best_models=args.save_best_models,
         reward_function_timeout=args.reward_function_timeout,
-        output_directory=args.output_directory
-        
+        output_directory=args.output_directory,
+        start_iteration=args.start_iteration,
 
     )
 

--- a/es_at_scale/trainer/es_trainer.py
+++ b/es_at_scale/trainer/es_trainer.py
@@ -30,9 +30,26 @@ from es_at_scale.utils.reward_shaping import z_score
 
 
 class ESNcclLLM(LLM):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, engine_idx=0, **kwargs):
         #os.environ.pop("CUDA_VISIBLE_DEVICES", None)
         os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+        # Co-located single-GPU engines otherwise all resolve VLLM_DP_MASTER_PORT/
+        # VLLM_DP_RANK_LOCAL to 0 (unset -> vllm.envs default), so every engine
+        # computes the same TCPStore port and only the first one to bind wins.
+        os.environ["VLLM_DP_MASTER_PORT"] = str(29500 + int(engine_idx) * 100)
+        # Same reasoning for the torch.compile cache: identical model/config on
+        # every engine hashes to the same cache path, so concurrent compiles from
+        # co-located engines race on the same files (seen as spurious CUDA
+        # "invalid argument" errors during profiling). Give each its own tree.
+        default_cache_root = os.environ.get("VLLM_CACHE_ROOT", os.path.expanduser("~/.cache/vllm"))
+        os.environ["VLLM_CACHE_ROOT"] = os.path.join(default_cache_root, f"engine_{engine_idx}")
+        # Triton's own kernel cache (~/.triton/cache by default) is a separate
+        # cache from VLLM_CACHE_ROOT and races the same way if left shared.
+        default_triton_cache = os.environ.get("TRITON_CACHE_DIR", os.path.expanduser("~/.triton/cache"))
+        os.environ["TRITON_CACHE_DIR"] = os.path.join(os.path.dirname(default_triton_cache.rstrip("/")), f"engine_{engine_idx}_cache")
+        # And the NVIDIA driver's own PTX->SASS JIT cache (~/.nv/ComputeCache),
+        # a third independent shared cache with the same race potential.
+        os.environ["CUDA_CACHE_PATH"] = os.path.expanduser(f"~/.nv/ComputeCache_engine_{engine_idx}")
         super().__init__(*args, **kwargs)
 
 
@@ -242,8 +259,16 @@ class EvolutionStrategiesTrainer:
             for pg in pgs
         ]
 
-        engines = [
-            ray.remote(num_cpus=0, num_gpus=0, scheduling_strategy=strategy)(
+        # Engines are constructed one at a time (not fired off concurrently):
+        # co-located engines doing torch.compile/CUDA-graph capture at the same
+        # moment intermittently corrupt each other's compilation with spurious
+        # "CUDA driver error: invalid argument" failures, even with per-engine
+        # cache directories. Waiting for each engine's __init__ (via a cheap
+        # collective_rpc round trip, which queues behind __init__ in Ray's
+        # per-actor task order) before starting the next avoids the race.
+        engines = []
+        for idx, strategy in enumerate(strategies):
+            engine = ray.remote(num_cpus=0, num_gpus=0, scheduling_strategy=strategy)(
                 ESNcclLLM
             ).remote(
                 model=model_name,
@@ -254,9 +279,10 @@ class EvolutionStrategiesTrainer:
                 enable_prefix_caching=False,
                 enforce_eager=False,
                 gpu_memory_utilization=0.7,
+                engine_idx=idx,
             )
-            for strategy in strategies
-        ]
+            ray.get(engine.collective_rpc.remote("_set_seed", args=(0,)))
+            engines.append(engine)
         return engines, pgs
 
 

--- a/es_at_scale/trainer/es_trainer.py
+++ b/es_at_scale/trainer/es_trainer.py
@@ -12,7 +12,10 @@ from ray.util.placement_group import placement_group, remove_placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from vllm import LLM, SamplingParams
-from vllm.utils import get_ip, get_open_port
+try:
+    from vllm.utils.network_utils import get_ip, get_open_port  # vLLM >= 0.20ish
+except ImportError:
+    from vllm.utils import get_ip, get_open_port  # vLLM 0.11.0 (pinned by this repo)
 from transformers import AutoTokenizer
 
 

--- a/es_at_scale/trainer/es_trainer.py
+++ b/es_at_scale/trainer/es_trainer.py
@@ -280,7 +280,17 @@ class EvolutionStrategiesTrainer:
                 dtype=precision,
                 enable_prefix_caching=False,
                 enforce_eager=False,
-                gpu_memory_utilization=0.7,
+                gpu_memory_utilization=float(
+                    os.environ.get("ES_VLLM_GPU_MEM_UTIL", "0.7")
+                ),
+                # Unset by default -> vLLM uses the model's own max_model_len.
+                # On small-VRAM cards the KV cache cannot hold that (Qwen2.5's
+                # 131072) and vLLM refuses to start; cap it at prompt+max_tokens.
+                **(
+                    {"max_model_len": int(os.environ["ES_VLLM_MAX_MODEL_LEN"])}
+                    if os.environ.get("ES_VLLM_MAX_MODEL_LEN")
+                    else {}
+                ),
                 engine_idx=idx,
             )
             ray.get(engine.collective_rpc.remote("_set_seed", args=(0,)))

--- a/es_at_scale/trainer/es_trainer.py
+++ b/es_at_scale/trainer/es_trainer.py
@@ -80,7 +80,8 @@ class EvolutionStrategiesTrainer:
         save_best_models=True,# If True, save a checkpoint whenever a new best eval score is achieved, final model is always saved to disk upon training completion
         experiment_name=None, # Human-readable run name used in W&B and checkpoint paths; auto-generated if None
         wandb_project=None,   # W&B project to log to; only used when logging="wandb"
-        reward_function_timeout=60  # Seconds before a reward function call is killed and assigned 0.0
+        reward_function_timeout=60,  # Seconds before a reward function call is killed and assigned 0.0
+        start_iteration=0,    # Iteration number to resume counting/seeding from when loading a checkpoint
 
     ):
         # GPU init
@@ -113,6 +114,7 @@ class EvolutionStrategiesTrainer:
         self.global_seed = global_seed
         self.output_directory = output_directory
         self.save_best_models = save_best_models
+        self.start_iteration = start_iteration
 
         self.train_dataloader = train_dataloader
         self.eval_dataloader_dict = eval_dataloader_dict
@@ -611,7 +613,7 @@ class EvolutionStrategiesTrainer:
                 )
 
     def fit(self):
-        iteration, epoch = 0, 0
+        iteration, epoch = self.start_iteration, 0
         done = False
 
         self.eval_step(iteration=iteration)

--- a/es_at_scale/utils/worker_extension.py
+++ b/es_at_scale/utils/worker_extension.py
@@ -169,9 +169,9 @@ class WorkerExtension:
         print(f"Model weights saved to {filepath}.")
 
     def load_weights_from_disk(self, filepath):
-        state_dict = torch.load(filepath, map_location=self.device)
+        state_dict = torch.load(filepath, map_location="cpu")
         for name, p in self.model_runner.model.named_parameters():
-            p.data.copy_(state_dict[name].to(self.device))
+            p.data.copy_(state_dict[name])
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()


### PR DESCRIPTION
Three independent fixes needed to run this on a single-node multi-GPU box:

1. vLLM >= 0.20 moved get_ip/get_open_port to vllm.utils.network_utils; this repo pins 0.11.0 where the old path still works. Falls back to the old import so both work.
2. Co-located engines on one node all resolve VLLM_DP_MASTER_PORT and several caches (vLLM's own, Triton's, the CUDA driver's PTX->SASS JIT cache) to the same shared default, so they race on ports/cache files — surfaced as spurious 'CUDA driver error: invalid argument' during construction. Each engine now gets its own port offset and cache trees, and engines are constructed sequentially (with a cheap collective_rpc barrier) since concurrent torch.compile/CUDA-graph capture across co-located engines corrupted each other even with separate caches.
3. --start-iteration lets a resumed run continue its iteration/epoch counter and per-iteration noise seeding from where a loaded checkpoint left off, instead of always restarting at 0.

Verified: training previously failed with the errors in #2 on a multi-GPU single-node RTX 4090 cluster; runs to completion with these three fixes applied.