### PR TITLE
Updating setup.py to remove unnecessary futures package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ required = [
     "accelerate>=0.20.0",
     "matplotlib>=3.5.0",
     "psutil",
-    "futures",
     # "flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiTRUE-cp310-cp310-linux_x86_64.whl",
     "black==22.8.0",
     "flake8==5.0.4",


### PR DESCRIPTION
Removes futures from the required dependencies in setup.py. 
This package is a backport of concurrent.futures for Python 2 and is unnecessary on Python 3, where the module is included in the standard library. And since this repo recommends Python >= 3.12, the removal won't make any problems. Without removing `futures`, uv throws this error:

```
Resolved 156 packages in 2.36s
      Built es-at-scale @ file:///Users/2453646/CognizantWork/es-at-scale
  × Failed to build `futures==3.4.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stderr]
      This backport is meant only for Python 2.
      It does not work on Python 3, and Python 3 users do not need it as the
      concurrent.futures package is available in the standard library.
      For projects that work on both Python 2 and 3, the dependency needs to be
      conditional on the Python version, like so:
      extras_require={':python_version == "2.7"': ['futures']}


hint: `futures` (v3.4.0) was included because `es-at-scale` (v0.0.1) depends on `futures`
hint: Build failures usually indicate a problem with the package or the build environment%                           
```

